### PR TITLE
Global system configs for shortener

### DIFF
--- a/lib/BasicShortener.php
+++ b/lib/BasicShortener.php
@@ -31,6 +31,12 @@ class BasicShortener implements Shortener
     public function __construct($container)
     {
         $this->config = $container['ini']['basicshortener'];
+
+        $cfg = \Config::getInstance();
+        // Global system configuration takes precedence over shortener url in config file
+        if (!empty($cfg->getValue('CLIQR_BASIC_SHORTENER_URL'))) {
+            $this->config['url'] = $cfg->getValue('CLIQR_BASIC_SHORTENER_URL');
+        }
     }
 
     public function shorten($url)

--- a/lib/Container.php
+++ b/lib/Container.php
@@ -55,8 +55,15 @@ class Container extends \Pimple
 
         $this['shortener'] = $this->share(
             function ($c) use ($base_path) {
-                require_once $base_path.$c['ini']['shortener']['file'];
-                $class = $c['ini']['shortener']['class'];
+                $cfg = \Config::getInstance();
+                if (!empty($cfg->getValue('CLIQR_URL_SHORTENER_CLASS'))) {
+                    $class = $cfg->getValue('CLIQR_URL_SHORTENER_CLASS');
+                    require_once "{$base_path}lib/$class.php";
+                    $class = "\\Cliqr\\$class";
+                } else {
+                    require_once $base_path.$c['ini']['shortener']['file'];
+                    $class = $c['ini']['shortener']['class'];
+                }
 
                 return new $class($c);
             }

--- a/migrations/04_create_shortener_configs.php
+++ b/migrations/04_create_shortener_configs.php
@@ -1,0 +1,34 @@
+<?php
+class CreateShortenerConfigs extends Migration
+{
+    public function description()
+    {
+        return "create configuration entries for the URL shortener";
+    }
+
+    public function up()
+    {
+        $cfg = Config::getInstance();
+        $cfg->create('CLIQR_URL_SHORTENER_CLASS', [
+            'type'        => 'string',
+            'description' => 'Klasse des zu verwendenden URL Shorteners. Gegenüber der Konfigurationsdatei hat diese Konfiguration Vorrang. Verfügbare Shortener-Klassen: BasicShortener, MockShortener, GoogleShortener, YourlsShortener'
+        ]);
+        $cfg->create('CLIQR_BASIC_SHORTENER_URL', [
+            'type'        => 'string',
+            'description' => 'URL für den BasicShortener, die den Wert in der Konfigurationsdatei überschreibt. Beispiel: https://vt.uos.de/shorten.php?longurl=%s'
+        ]);
+
+        $cfg->delete('CLIQR_URL_SHORTENER_API_KEY');
+    }
+
+    public function down()
+    {
+        $cfg = Config::getInstance();
+        $cfg->delete("CLIQR_URL_SHORTENER_CLASS");
+        $cfg->delete("CLIQR_BASIC_SHORTENER_URL");
+
+        $cfg->create('CLIQR_URL_SHORTENER_API_KEY', [
+            'comment' => 'API Key für den Zugriff auf die Google URL Shortener API'
+        ]);
+    }
+}


### PR DESCRIPTION
There is currently no way to configure the shortener via the global admin configuration. The config file has the main drawback of being overwritten by updates. These changes add an easy way to select a shortener and configure a URL for the base shortener.

Changes:
- Add new configurations for the shortener
    - `CLIQR_URL_SHORTENER_CLASS`: Shortener class name to be used
    - `CLIQR_BASIC_SHORTENER_URL`: Url of the base shortener
    - Both configurations take precedence over the configuration file